### PR TITLE
Update Gemini model to gemini-2.5-flash-preview-05-20

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-const API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+const API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent';
 const API_KEY = process.env.GEMINI_API_KEY;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
This commit updates the API_URL in pages/api/generate.ts to use the new Gemini model "gemini-2.5-flash-preview-05-20".